### PR TITLE
fixed some exceptions, corrected plurals, added confirm messages when…

### DIFF
--- a/src/Actions/ChoosePlantField.cs
+++ b/src/Actions/ChoosePlantField.cs
@@ -60,14 +60,26 @@ namespace Trestlebridge.Actions {
 
             if (fieldTypeNum == 1) {
                 farm.PlowedFields[choice].AddResource (Plant);
+                Console.WriteLine("Congrats! You've planted a row of Sesame seeds in a plowed field.");
+                Console.WriteLine("Press return to go back to the main menu.");
+                Console.ReadLine();
             } else if (fieldTypeNum == 2) {
                 farm.NaturalFields[choice].AddResource (Plant);
+                Console.WriteLine("Congrats! You've planted a row of Wildflower seeds in a natural field.");
+                Console.WriteLine("Press return to go back to the main menu.");
+                Console.ReadLine();
             } else {
                 if (choice > farm.NaturalFields.Count - 1) {
                     choice = choice - farm.NaturalFields.Count;
                     farm.PlowedFields[choice].AddResource (Plant);
+                    Console.WriteLine("Congrats! You've planted a row of Sunflower seeds in a plowed field.");
+                    Console.WriteLine("Press return to go back to the main menu.");
+                    Console.ReadLine();
                 } else {
                     farm.NaturalFields[choice].AddResource (Plant);
+                    Console.WriteLine("Congrats! You've planted a row of Sunflower seeds in a natural field.");
+                    Console.WriteLine("Press return to go back to the main menu.");
+                    Console.ReadLine();
                 }
 
             }

--- a/src/Actions/CreateFacility.cs
+++ b/src/Actions/CreateFacility.cs
@@ -16,46 +16,53 @@ namespace Trestlebridge.Actions
             Console.WriteLine("5. Chicken House");
 
             Console.WriteLine();
-            Console.WriteLine("Choose what you want to create");
+            Console.WriteLine("Choose what you want to create or hit return to exit");
 
             Console.Write("> ");
             string input = Console.ReadLine();
 
-            switch (Int32.Parse(input))
+            try
             {
-                case 1:
-                    farm.AddGrazingField(new GrazingField());
-                    Console.WriteLine("Congrats! You've created a grazing field.");
-                    Console.WriteLine("Press return to go back to the main menu.");
-                    Console.ReadLine();
-                    break;
-                case 2:
-                    farm.AddPlowedField(new PlowedField());
-                    Console.WriteLine("Congrats! You've created a plowed field.");
-                    Console.WriteLine("Press return to go back to the main menu.");
-                    Console.ReadLine();
-                    break;
-                case 3:
-                    farm.AddNaturalField(new NaturalField());
-                    Console.WriteLine("Congrats! You've created a natural field.");
-                    Console.WriteLine("Press return to go back to the main menu.");
-                    Console.ReadLine();
-                    break;
+                switch (Int32.Parse(input))
+                {
+                    case 1:
+                        farm.AddGrazingField(new GrazingField());
+                        Console.WriteLine("Congrats! You've created a grazing field.");
+                        Console.WriteLine("Press return to go back to the main menu.");
+                        Console.ReadLine();
+                        break;
+                    case 2:
+                        farm.AddPlowedField(new PlowedField());
+                        Console.WriteLine("Congrats! You've created a plowed field.");
+                        Console.WriteLine("Press return to go back to the main menu.");
+                        Console.ReadLine();
+                        break;
+                    case 3:
+                        farm.AddNaturalField(new NaturalField());
+                        Console.WriteLine("Congrats! You've created a natural field.");
+                        Console.WriteLine("Press return to go back to the main menu.");
+                        Console.ReadLine();
+                        break;
 
-                case 4:
-                    farm.AddDuckHouse(new DuckHouse());
-                    Console.WriteLine("Congrats! You've created a duck house.");
-                    Console.WriteLine("Press return to go back to the main menu.");
-                    Console.ReadLine();
-                    break;
-                case 5:
-                    farm.AddChickenHouse(new ChickenHouse());
-                    Console.WriteLine("Congrats! You've created a chicken house.");
-                    Console.WriteLine("Press return to go back to the main menu.");
-                    Console.ReadLine();
-                    break;
-                default:
-                    break;
+                    case 4:
+                        farm.AddDuckHouse(new DuckHouse());
+                        Console.WriteLine("Congrats! You've created a duck house.");
+                        Console.WriteLine("Press return to go back to the main menu.");
+                        Console.ReadLine();
+                        break;
+                    case 5:
+                        farm.AddChickenHouse(new ChickenHouse());
+                        Console.WriteLine("Congrats! You've created a chicken house.");
+                        Console.WriteLine("Press return to go back to the main menu.");
+                        Console.ReadLine();
+                        break;
+                    default:
+                        break;
+                }
+            }
+            catch (FormatException)
+            {
+
             }
         }
     }

--- a/src/Actions/CreateFacility.cs
+++ b/src/Actions/CreateFacility.cs
@@ -43,7 +43,6 @@ namespace Trestlebridge.Actions
                         Console.WriteLine("Press return to go back to the main menu.");
                         Console.ReadLine();
                         break;
-
                     case 4:
                         farm.AddDuckHouse(new DuckHouse());
                         Console.WriteLine("Congrats! You've created a duck house.");

--- a/src/Actions/PurchaseSeedStock.cs
+++ b/src/Actions/PurchaseSeedStock.cs
@@ -12,23 +12,30 @@ namespace Trestlebridge.Actions {
             Console.WriteLine ("3. Wildflower");
 
             Console.WriteLine ();
-            Console.WriteLine ("What are you buying today?");
+            Console.WriteLine ("What are you buying today? Hit return to exit");
 
             Console.Write ("> ");
             string choice = Console.ReadLine ();
 
-            switch (Int32.Parse (choice)) {
-                case 1:
-                    ChoosePlantField.CollectPlantInput (farm, new Sesame (), 1);
-                    break;
-                case 2:
-                    ChoosePlantField.CollectPlantInput (farm, new Sunflower (), 3);
-                    break;
-                case 3:
-                    ChoosePlantField.CollectPlantInput (farm, new Wildflower (), 2);
-                    break;
-                default:
-                    break;
+            try
+            {
+                switch (Int32.Parse (choice)) {
+                    case 1:
+                        ChoosePlantField.CollectPlantInput (farm, new Sesame (), 1);
+                        break;
+                    case 2:
+                        ChoosePlantField.CollectPlantInput (farm, new Sunflower (), 3);
+                        break;
+                    case 3:
+                        ChoosePlantField.CollectPlantInput (farm, new Wildflower (), 2);
+                        break;
+                    default:
+                        break;
+                }
+            }
+            catch (FormatException)
+            {
+            
             }
         }
     }

--- a/src/Actions/PurchaseStock.cs
+++ b/src/Actions/PurchaseStock.cs
@@ -16,35 +16,42 @@ namespace Trestlebridge.Actions {
             Console.WriteLine ("7. Chicken");
 
             Console.WriteLine ();
-            Console.WriteLine ("What are you buying today?");
+            Console.WriteLine ("What are you buying today? Hit return to exit");
 
             Console.Write ("> ");
             string choice = Console.ReadLine ();
 
-            switch (Int32.Parse (choice)) {
-                case 1:
-                    ChooseGrazingField.CollectInput (farm, new Cow ());
-                    break;
-                case 2:
-                    ChooseGrazingField.CollectInput (farm, new Ostrich ());
-                    break;
-                case 3:
-                    ChooseGrazingField.CollectInput (farm, new Pig ());
-                    break;
-                case 4:
-                    ChooseGrazingField.CollectInput (farm, new Goat ());
-                    break;
-                case 5:
-                    ChooseGrazingField.CollectInput (farm, new Sheep ());
-                    break;
-                case 6:
-                    ChooseDuckHouse.CollectInput (farm, new Duck ());
-                    break;
-                case 7:
-                    ChooseChickenHouse.CollectInput (farm, new Chicken ());
-                    break;
-                default:
-                    break;
+            try
+            {
+                switch (Int32.Parse (choice)) {
+                    case 1:
+                        ChooseGrazingField.CollectInput (farm, new Cow ());
+                        break;
+                    case 2:
+                        ChooseGrazingField.CollectInput (farm, new Ostrich ());
+                        break;
+                    case 3:
+                        ChooseGrazingField.CollectInput (farm, new Pig ());
+                        break;
+                    case 4:
+                        ChooseGrazingField.CollectInput (farm, new Goat ());
+                        break;
+                    case 5:
+                        ChooseGrazingField.CollectInput (farm, new Sheep ());
+                        break;
+                    case 6:
+                        ChooseDuckHouse.CollectInput (farm, new Duck ());
+                        break;
+                    case 7:
+                        ChooseChickenHouse.CollectInput (farm, new Chicken ());
+                        break;
+                    default:
+                        break;
+                }
+            }
+            catch (FormatException)
+            {
+                
             }
         }
     }

--- a/src/Models/Facilities/ChickenHouse.cs
+++ b/src/Models/Facilities/ChickenHouse.cs
@@ -32,14 +32,29 @@ namespace Trestlebridge.Models.Facilities {
         }
 
         public string AnimalCount () {
-            return $"({this._animals.Count} chickens)";
+            if (this._animals.Count == 1)
+            {
+                return $"({this._animals.Count} chicken)";
+            }
+            else
+            {
+                return $"({this._animals.Count} chickens)";
+            }
         }
 
         public override string ToString () {
             StringBuilder output = new StringBuilder ();
             string shortId = $"{this._id.ToString().Substring(this._id.ToString().Length - 6)}";
 
-            output.Append ($"Chicken house {shortId} has {this._animals.Count} chickens\n");
+            if (this._animals.Count == 1)
+            {
+                output.Append ($"Chicken house {shortId} has {this._animals.Count} chicken\n");
+            }
+            else
+            {
+                output.Append ($"Chicken house {shortId} has {this._animals.Count} chickens\n");
+            }
+
             this._animals.ForEach (a => output.Append ($"   {a}\n"));
 
             return output.ToString ();

--- a/src/Models/Facilities/DuckHouse.cs
+++ b/src/Models/Facilities/DuckHouse.cs
@@ -38,14 +38,29 @@ namespace Trestlebridge.Models.Facilities {
         }
 
         public string AnimalCount () {
-            return $"({this._animals.Count} ducks)";
+            if (this._animals.Count == 1)
+            {
+                return $"({this._animals.Count} duck)";
+            }
+            else
+            {
+                return $"({this._animals.Count} ducks)";
+            }
         }
 
         public override string ToString () {
             StringBuilder output = new StringBuilder ();
             string shortId = $"{this._id.ToString().Substring(this._id.ToString().Length - 6)}";
-
-            output.Append ($"Duck house {shortId} has {this._animals.Count} ducks\n");
+            
+            if (this._animals.Count == 1)
+            {
+                output.Append ($"Duck house {shortId} has {this._animals.Count} duck\n");
+            }
+            else
+            {
+                output.Append ($"Duck house {shortId} has {this._animals.Count} ducks\n");
+            }
+            
             this._animals.ForEach (a => output.Append ($"   {a}\n"));
 
             return output.ToString ();

--- a/src/Models/Facilities/GrazingField.cs
+++ b/src/Models/Facilities/GrazingField.cs
@@ -55,7 +55,14 @@ namespace Trestlebridge.Models.Facilities {
 
         public string AnimalCount()
         {
-            return $"({this._animals.Count} animals)";
+            if (this._animals.Count == 1)
+            {
+                return $"({this._animals.Count} animal)";
+            }
+            else
+            {
+                return $"({this._animals.Count} animals)";
+            }
         }
 
         public void AnimalTypeCount()

--- a/src/Models/Facilities/NaturalField.cs
+++ b/src/Models/Facilities/NaturalField.cs
@@ -41,7 +41,7 @@ namespace Trestlebridge.Models.Facilities {
             }
             else
             {
-            output.Append ($"Natural field {shortId} has {this._plants.Count} rows of plants\n");
+                output.Append ($"Natural field {shortId} has {this._plants.Count} rows of plants\n");
             }
             
             this._plants.ForEach (a => output.Append ($"   {a}\n"));
@@ -52,11 +52,11 @@ namespace Trestlebridge.Models.Facilities {
         public string PlantCount () {
             if (this._plants.Count == 1)
             {
-            return $"({this._plants.Count} row of plants)";
+                return $"({this._plants.Count} row of plants)";
             }
             else
             {
-            return $"({this._plants.Count} rows of plants)";
+                return $"({this._plants.Count} rows of plants)";
             }
         }
         public void PlantTypeCount () {

--- a/src/Models/Facilities/NaturalField.cs
+++ b/src/Models/Facilities/NaturalField.cs
@@ -34,15 +34,30 @@ namespace Trestlebridge.Models.Facilities {
         public override string ToString () {
             StringBuilder output = new StringBuilder ();
             string shortId = $"{this._id.ToString().Substring(this._id.ToString().Length - 6)}";
-
-            output.Append ($"Natural field {shortId} has {this._plants.Count} plants\n");
+            
+            if (this._plants.Count == 1)
+            {
+                output.Append ($"Natural field {shortId} has {this._plants.Count} row of plants\n");
+            }
+            else
+            {
+            output.Append ($"Natural field {shortId} has {this._plants.Count} rows of plants\n");
+            }
+            
             this._plants.ForEach (a => output.Append ($"   {a}\n"));
 
             return output.ToString ();
         }
 
         public string PlantCount () {
-            return $"({this._plants.Count} plants)";
+            if (this._plants.Count == 1)
+            {
+            return $"({this._plants.Count} row of plants)";
+            }
+            else
+            {
+            return $"({this._plants.Count} rows of plants)";
+            }
         }
         public void PlantTypeCount () {
             if (this._plants.Count > 0) {
@@ -57,9 +72,9 @@ namespace Trestlebridge.Models.Facilities {
 
                 foreach (var report in PlantTypeCount) {
                     if (report.PlantCount == 1) {
-                        Console.Write ($"({report.PlantCount} {report.PlantType}) ");
+                        Console.Write ($"({report.PlantCount} row of {report.PlantType}s) ");
                     } else {
-                        Console.Write ($"({report.PlantCount} {report.PlantType}s) ");
+                        Console.Write ($"({report.PlantCount} rows of {report.PlantType}s) ");
                     }
                 }
             }

--- a/src/Models/Facilities/PlowingField.cs
+++ b/src/Models/Facilities/PlowingField.cs
@@ -35,13 +35,29 @@ namespace Trestlebridge.Models.Facilities {
             StringBuilder output = new StringBuilder ();
             string shortId = $"{this._id.ToString().Substring(this._id.ToString().Length - 6)}";
 
-            output.Append ($"Plowed field {shortId} has {this._plants.Count} plants\n");
+            if (this._plants.Count == 1)
+            {
+                output.Append ($"Plowed field {shortId} has {this._plants.Count} row of plants\n");
+            }
+            else
+            {
+                output.Append ($"Plowed field {shortId} has {this._plants.Count} rows of plants\n");
+            }
+            
+            
             this._plants.ForEach (a => output.Append ($"   {a}\n"));
 
             return output.ToString ();
         }
         public string PlantCount () {
-            return $"({this._plants.Count} plants)";
+            if (this._plants.Count == 1)
+            {
+            return $"({this._plants.Count} row of plants)";
+            }
+            else
+            {
+            return $"({this._plants.Count} rows of plants)";
+            }
         }
         public void PlantTypeCount () {
             if (this._plants.Count > 0) {
@@ -56,9 +72,9 @@ namespace Trestlebridge.Models.Facilities {
 
                 foreach (var report in PlantTypeCount) {
                     if (report.PlantCount == 1) {
-                        Console.Write ($"({report.PlantCount} {report.PlantType}) ");
+                        Console.Write ($"({report.PlantCount} row of {report.PlantType}s) ");
                     } else {
-                        Console.Write ($"({report.PlantCount} {report.PlantType}s) ");
+                        Console.Write ($"({report.PlantCount} rows of {report.PlantType}s) ");
                     }
                 }
             }

--- a/src/Models/Facilities/PlowingField.cs
+++ b/src/Models/Facilities/PlowingField.cs
@@ -52,11 +52,11 @@ namespace Trestlebridge.Models.Facilities {
         public string PlantCount () {
             if (this._plants.Count == 1)
             {
-            return $"({this._plants.Count} row of plants)";
+                return $"({this._plants.Count} row of plants)";
             }
             else
             {
-            return $"({this._plants.Count} rows of plants)";
+                return $"({this._plants.Count} rows of plants)";
             }
         }
         public void PlantTypeCount () {


### PR DESCRIPTION
… putting in a new row of flowers

There were format exceptions being thrown whenever a blank string or random letters were entered when creating a facility, purchasing an animal, or purchasing a plant so I put in some try-catches to fix those and just added "or hit return to exit" if you wanted to go back to the main menu.

Put some if else statements in for when there was one of an animal in something it will say 1 chicken instead of 1 chickens as well as changing the flowers to saying 1 row of Sunflowers or 2 rows of Sunflowers etc, instead of saying 1 Sunflower as each "1" represents a row.

Also, I was just looking through tickets to make sure we didn't miss something on one of them and I found that the one that's now under "ready to test" wanted a confirm message added when you added a plant to a field so I set those up and to test those you'll have to create a natural or plowed field and simply add a flower to it and similarly to creating fields, it gives you a congrats confirm message and youll have to hit enter to get back to the main menu.